### PR TITLE
Compact multiple NEEDS blocks in patches

### DIFF
--- a/Mk3Expansion-1.4.7/GameData/Mk3Expansion/Patches/M3X_FuelTankSwitch.cfg
+++ b/Mk3Expansion-1.4.7/GameData/Mk3Expansion/Patches/M3X_FuelTankSwitch.cfg
@@ -1,7 +1,7 @@
 // Adds FSFuelSwitch to fuel containing mod parts
 // LF,LF/O, Structural variants
 
-@PART[M3X_Size2Bicoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_Size2Bicoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -26,7 +26,7 @@
 		}
 	}
 }
-@PART[M3X_hypersonicnosecone]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_hypersonicnosecone]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
 	MODULE
 	{
@@ -51,7 +51,7 @@
 		}
 	}
 }
-@PART[M3X_InverterAdaptermk2]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_InverterAdaptermk2]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
    	MODULE
 	{
@@ -76,7 +76,7 @@
 		}
 	}
 }
-@PART[M3X_size1adapter]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_size1adapter]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -102,7 +102,7 @@
 }
 
 }
-@PART[M3X_Quadcoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_Quadcoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -128,7 +128,7 @@
 }
 
 }
-@PART[M3X_nosecap]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_nosecap]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -153,7 +153,7 @@
 		}
 }
 }
-@PART[M3X_Tricoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_Tricoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -179,7 +179,7 @@
 }
 
 }
-@PART[M3X_Mk2Tricoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_Mk2Tricoupler]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -205,7 +205,7 @@
 }
 
 }
-@PART[M3X_THub]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_THub]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -231,7 +231,7 @@
 }
 
 }
-@PART[M3X_XHub]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_XHub]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -257,7 +257,7 @@
 }
 
 }
-@PART[M3X_XHub]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_XHub]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{
@@ -283,7 +283,7 @@
 }
 
 }
-@PART[M3X_ShortAdapter]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks]:NEEDS[!RealFuels]:NEEDS[!KerbalAtomics]
+@PART[M3X_ShortAdapter]:HAS[!MODULE[InterstellarFuelSwitch],!MODULE[ModuleTankManager],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines],!MODULE[FSfuelSwitch]]:NEEDS[!modularFuelTanks,!RealFuels,!KerbalAtomics]
 {
     	MODULE
 	{

--- a/Mk3Expansion-1.4.7/GameData/Mk3Expansion/Patches/M3X_KA.cfg
+++ b/Mk3Expansion-1.4.7/GameData/Mk3Expansion/Patches/M3X_KA.cfg
@@ -1,5 +1,5 @@
 // Kerbal Atomics Patch
-@PART[M3X_Hades]:NEEDS[KerbalAtomics]:NEEDS[!KSPIntegration]:FOR[Mk3Expansion]
+@PART[M3X_Hades]:NEEDS[KerbalAtomics,!KSPIntegration]:FOR[Mk3Expansion]
 {
 	@MODULE[ModuleEnginesFX]   {
 		@PROPELLANT[LiquidFuel] 

--- a/Mk3Expansion-1.4.7/GameData/Mk3Expansion/Patches/M3X_NFE_Functionality.cfg
+++ b/Mk3Expansion-1.4.7/GameData/Mk3Expansion/Patches/M3X_NFE_Functionality.cfg
@@ -1,4 +1,4 @@
-@PART[M3X_Hades]:NEEDS[NearFutureElectrical]:NEEDS[!KSPIntegration]:FOR[Mk3Expansion]
+@PART[M3X_Hades]:NEEDS[NearFutureElectrical,!KSPIntegration]:FOR[Mk3Expansion]
 {
 @mass = 12.8
 MODULE
@@ -124,7 +124,7 @@ MODULE
 	}
 
 }
-@PART[M3X_NuclearJet]:NEEDS[NearFutureElectrical]:NEEDS[!KSPIntegration]:FOR[Mk3Expansion]
+@PART[M3X_NuclearJet]:NEEDS[NearFutureElectrical,!KSPIntegration]:FOR[Mk3Expansion]
 {
 @mass = 12.8
 MODULE
@@ -248,7 +248,7 @@ MODULE
 	}
 }
 
-@PART[M3X_Reactor]:NEEDS[NearFutureElectrical]:NEEDS[!KSPIntegration]:FOR[Mk3Expansion]
+@PART[M3X_Reactor]:NEEDS[NearFutureElectrical,!KSPIntegration]:FOR[Mk3Expansion]
 {
 @description = A stripped down experimental fission reactor intended for use aboard aerospace assets that produces up to 1500kW of electric power. 
 !MODULE[ModuleResourceConverter] {}


### PR DESCRIPTION
The current ModuleManager gives warnings about multiple NEEDS blocks and ignores all but the first.

I think I found them all.